### PR TITLE
Add recording Outbound calls

### DIFF
--- a/vocode/streaming/telephony/client/twilio_client.py
+++ b/vocode/streaming/telephony/client/twilio_client.py
@@ -54,8 +54,14 @@ class TwilioClient(AbstractTelephonyClient):
             "From": f"+{from_phone}",
             **(telephony_params or {}),
         }
+
         if digits:
             data["SendDigits"] = digits
+        
+        if record:
+            data["Record"] = "true"  # Enables recording
+            data["RecordingChannels"] = "dual"  # Ensures separate caller & receiver channels
+
         async with AsyncRequestor().get_session().post(
             f"https://api.twilio.com/2010-04-01/Accounts/{self.twilio_config.account_sid}/Calls.json",
             auth=self.auth,


### PR DESCRIPTION
This pull request includes an enhancement to the `vocode/streaming/telephony/client/twilio_client.py` file, specifically in the `create_call` method. The most important change is the addition of functionality to enable call recording with separate channels for the caller and receiver.

Enhancements to `create_call` method:

* Added a check for the `record` parameter to enable call recording. When `record` is true, the `Record` key is set to "true" and the `RecordingChannels` key is set to "dual" to ensure separate channels for the caller and receiver.